### PR TITLE
Depend on released version of poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,7 @@ multi_line_output = 3 # Vertical Hanging Indent
 src_paths = "tap_linear"
 
 [build-system]
-# Uncomment the pinned version in favor of the git URL once
-# https://github.com/python-poetry/poetry-core/pull/257 is merged
-# and a new poetry-core 1.0.x is released
-# requires = ["poetry-core>=1.0.0"]
-requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
The git url was not valid anymore since poetry-core switched the default branch from master to main.